### PR TITLE
Add VC Status List 2021.

### DIFF
--- a/specifications/status-list-2021.json
+++ b/specifications/status-list-2021.json
@@ -1,0 +1,10 @@
+{
+  "name": "Status List (v2021)",
+  "summary": "A credential status list with herd privacy characteristics.",
+  "specification": "https://w3c.github.io/vc-status-list-2021/",
+  "category": "credentialStatus",
+  "maintainerEmail": "public-vc-wg@w3.org",
+  "maintainerName": "W3C Verifiable Credentials Working Group",
+  "maintainerWebsite": "https://www.w3.org/groups/wg/vc",
+  "vocabulary": ["https://raw.githubusercontent.com/w3c/vc-status-list-2021/main/contexts/v1.jsonld"]
+}


### PR DESCRIPTION
This PR adds VC Status List 2021 to the VC Specs Directory.