### PR TITLE
Add "Media Type Extensions" category.

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@ An URL that resolves to a human readable specification. For example:
               <td>
 The Verifiable Credential extension category of the specification, which can
 be one of the following values: `credentialStatus`, `credentialSchema`,
-`evidence`, `proof`, `refreshService`, `termsOfUse`, or `vc`.
+`evidence`, `media-type`, `proof`, `refreshService`, `termsOfUse`, or `vc`.
 For example: `credentialStatus`.
               <p class="note">
 The extensions might define a `@type`. See [[JSON-LD11]].
@@ -391,7 +391,19 @@ yml2vocab or JSON-LD format. For example:
     </table>
 
   </section>
+  <section>
+    <h1>Media Type Extensions</h1>
 
+    <table class="simple">
+      <thead>
+        <th>Specification</th><th>Description</th>
+      </thead>
+      <tbody id="media-type-table">
+
+      </tbody>
+    </table>
+
+  </section>
 
 </body>
 </html>

--- a/specifications/vc-jwt.json
+++ b/specifications/vc-jwt.json
@@ -1,7 +1,7 @@
 {
-  "name": "application/vc+jwt",
-  "summary": "Securing Verifiable Credentials using JSON Web Tokens.",
-  "specification": "https://w3c.github.io/vc-jwt/",
+  "name": "application/vc+ld+json+jwt",
+  "summary": "Securing Verifiable Credentials using JOSE and COSE",
+  "specification": "https://www.w3.org/TR/vc-jose-cose/",
   "category": "media-type",
   "maintainerEmail": "public-vc-wg@w3.org",
   "maintainerName": "W3C Verifiable Credentials Working Group",

--- a/specifications/vc-jwt.json
+++ b/specifications/vc-jwt.json
@@ -1,0 +1,9 @@
+{
+  "name": "application/vc+jwt",
+  "summary": "Securing Verifiable Credentials using JSON Web Tokens.",
+  "specification": "https://w3c.github.io/vc-jwt/",
+  "category": "media-type",
+  "maintainerEmail": "public-vc-wg@w3.org",
+  "maintainerName": "W3C Verifiable Credentials Working Group",
+  "maintainerWebsite": "https://www.w3.org/groups/wg/vc"
+}

--- a/tooling/specification-entry.yml
+++ b/tooling/specification-entry.yml
@@ -30,6 +30,7 @@ properties:
       - credentialStatus
       - credentialSchema
       - evidence
+      - media-type
       - proof
       - refreshService
       - termsOfUse


### PR DESCRIPTION
This PR adds a "Media Type Extensions" section, and an example of it's usage by adding the `application/vc+jwt` media type to the section. The result is a section that looks like this in the vc-specs-dir:

![image](https://user-images.githubusercontent.com/108611/230739028-fe08b9d6-3d3e-4253-991d-24b249f58456.png)

This is an attempt to partially implement [the resolution made at the 2023 Miami VCWG F2F Meeting](https://www.w3.org/2017/vc/WG/Meetings/Minutes/2023-02-16-vcwg#resolution1) and the tracking issue in vc-data-model: https://github.com/w3c/vc-data-model/issues/1048


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-specs-dir/pull/14.html" title="Last updated on Aug 4, 2023, 7:48 PM UTC (2f3c104)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-specs-dir/14/791b578...2f3c104.html" title="Last updated on Aug 4, 2023, 7:48 PM UTC (2f3c104)">Diff</a>