### PR TITLE
Add PreconditionPolicy Terms of Use extension.

### DIFF
--- a/specifications/precondition-policy.json
+++ b/specifications/precondition-policy.json
@@ -1,0 +1,9 @@
+{
+	"name": "Precondition Policy",
+	"summary": "Terms of Use for Chain Reaction Revocation",
+  "specification": "https://gist.github.com/MizukiSonoko/87a11fbcea64b13ccc6873fcbe14cd1a",
+	"category": "termsOfUse",
+	"maintainerEmail": "sonoko@mizuki.io",
+	"maintainerName": "Taisei Igarashi",
+	"maintainerWebsite": "https://mizuki.io"
+} 

--- a/specifications/precondition-policy.json
+++ b/specifications/precondition-policy.json
@@ -1,9 +1,9 @@
 {
-	"name": "Precondition Policy",
-	"summary": "Terms of Use for Chain Reaction Revocation",
+  "name": "Precondition Policy",
+  "summary": "Terms of Use for Chain Reaction Revocation",
   "specification": "https://gist.github.com/MizukiSonoko/87a11fbcea64b13ccc6873fcbe14cd1a",
-	"category": "termsOfUse",
-	"maintainerEmail": "sonoko@mizuki.io",
-	"maintainerName": "Taisei Igarashi",
-	"maintainerWebsite": "https://mizuki.io"
+  "category": "termsOfUse",
+  "maintainerEmail": "sonoko@mizuki.io",
+  "maintainerName": "Taisei Igarashi",
+  "maintainerWebsite": "https://mizuki.io"
 } 


### PR DESCRIPTION
Hello.

I created the PR as an extension of this discussion in this issue. https://github.com/w3c/vc-data-model/issues/1072
I will revise if there is anything that needs to be quasi-written, such as procedures, specification notations, preservation, etc.
Thanks

## Instructions for Pull Requests
I propose PreconditionPolicy to TermOfUse for working chain reaction revocation correctly.

Currently, there is no normalized specification for the type of TermsOfUse, and each Issuer can define it independently. However, there are some problem, such as
- Without normalization, it is difficult to verify mechanical verification of chain reactive.
- It is necessary to check the policy of termsOfUse every time. PreconditionPolicy, VerifierPolicy and so on. Therefore, I propose to normalize it by the name of PreconditionPolicy in this Specification.  
 
So, I propose PreconditionPolicy to TermOfUse for working chain reaction revocation correctly.
I would appreciate your opinions.

## Adding Your Specification

In order to add your specification to this directory, you must add a JSON file to the [./specifications](./specifications) directory.

Here is an example specification entry:
```jsonc
{
  "name": "Precondition Policy",
  "summary": "Terms of Use for Chain Reaction Revocation",
  "specification": "https://gist.github.com/MizukiSonoko/87a11fbcea64b13ccc6873fcbe14cd1a",
  "category": "termsOfUse",
  "maintainerEmail": "sonoko@mizuki.io",
  "maintainerName": "Taisei Igarashi",
  "maintainerWebsite": "https://mizuki.io"
}
```

